### PR TITLE
Support for all asset types and mode configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ You will need to add the custom element to a content type filling in the hosted 
 {
   "bynderUrl": "https://<YOUR BYNDER URL>",
   "previewDerivative": "thumbnail",
-  "webDerivative": "webImage"
+  "webDerivative": "webImage",
+  "assetTypes": ["image"],
+  "selectionMode": "MultiSelect"
 }
 ```
 All of the parameters are optional. 
 If you don't provide bynder URL, the selector will prompt for it while logging in.
-The derivative parameters can be used to alter which of the defined image derivatives will be used by the selector preview and output. More details in [the official documentation](https://support.bynder.com/hc/en-us/articles/360013871360#UUID-efe6ac1b-c1aa-62e5-f086-45cafead8b51).
+The derivative parameters can be used to alter which of the defined asset derivatives will be used by the selector preview and output. More details in [the official documentation](https://support.bynder.com/hc/en-us/articles/360013871360#UUID-efe6ac1b-c1aa-62e5-f086-45cafead8b51).
 
 ## What is Saved
 

--- a/src/bynder-selector.js
+++ b/src/bynder-selector.js
@@ -8,9 +8,9 @@ function updateDisabled(disabled) {
     enabledElements.hide();
   }
   else {
-    enabledElements.show();  
+    enabledElements.show();
   }
-  
+
   isDisabled = disabled;
 }
 
@@ -20,31 +20,31 @@ function updateSize() {
 }
 
 function remove(id) {
-  const images = currentValue || [];
-  const newImages = images.filter(image => image.id !== id);
-  updateValue(newImages);
+  const assets = currentValue || [];
+  const newAssets = assets.filter(asset => asset.id !== id);
+  updateValue(newAssets);
 }
 
-function renderSelected(images) {
+function renderSelected(assets) {
   const $selected = $(".selected").empty();
-  if (images && images.length) {
-    for (var i = 0; i < images.length; i++) {
-      const image = images[i];
-      if (image) {
-        imageTile($selected, image, remove);
+  if (assets && assets.length) {
+    for (var i = 0; i < assets.length; i++) {
+      const asset = assets[i];
+      if (asset) {
+        assetTile($selected, asset, remove);
       }
     }
   }
   updateSize();
 }
 
-function updateValue(images) {
+function updateValue(assets) {
   // Send updated value to Kentico (send null in case of the empty string => element will not meet required condition).
   if (!isDisabled) {
-    if (images && images.length) {
-      currentValue = images;
-      CustomElement.setValue(JSON.stringify(images));
-      renderSelected(images);
+    if (assets && assets.length) {
+      currentValue = assets;
+      CustomElement.setValue(JSON.stringify(assets));
+      renderSelected(assets);
     }
     else {
       currentValue = null;
@@ -54,29 +54,29 @@ function updateValue(images) {
   }
 }
 
-function imageTile($parent, item, remove) {
+function assetTile($parent, asset, remove) {
   const $tile = $(`<div class="asset-thumbnail"></div>`).appendTo($parent);
   const $tileInside = $(`<div class="asset-preview"></div>`).appendTo($tile);
   const $actions = $('<div class="asset-thumbnail__actions-pane"></div>').appendTo($tileInside);
 
-  if (item.webUrl) {
-    $(`<a class="action" title="Download" href="${item.webUrl}" target="_blank"><i class="icon-arrow-down-line"></i></a>`).appendTo($actions);
+  if (asset.webUrl) {
+    $(`<a class="action" title="Download" href="${asset.webUrl}" target="_blank"><i class="icon-arrow-down-line"></i></a>`).appendTo($actions);
   }
 
-  $(`<a class="remove" title="Remove"><i class="icon-times"></i></a>`).appendTo($actions).click(function () {remove(item.id);});
+  $(`<a class="remove" title="Remove"><i class="icon-times"></i></a>`).appendTo($actions).click(function () { remove(asset.id); });
 
-  if (item.previewUrl) {
-    $(`<a href="${item.bynderUrl}" target="_blank"><img class="asset-thumbnail__image" src="${item.previewUrl}" /></a>`).appendTo($tileInside).on('load', updateSize);
+  if (asset.previewUrl) {
+    $(`<a href="${asset.bynderUrl}" target="_blank"><img class="asset-thumbnail__image" src="${asset.previewUrl}" /></a>`).appendTo($tileInside).on('load', updateSize);
   }
 
   else {
     $('<div class="noimage">No image available</div>').appendTo($tileInside);
   }
 
-  $(`<div class="asset-thumbnail__bottom">${item.name}</div>`).appendTo($tileInside);
+  $(`<div class="asset-thumbnail__bottom">${asset.name}</div>`).appendTo($tileInside);
 }
 
-function setupSelector(value) {  
+function setupSelector(value) {
   if (value) {
     currentValue = JSON.parse(value);
     renderSelected(currentValue);
@@ -88,33 +88,29 @@ function setupSelector(value) {
 
 function openCompactView() {
   CustomElement.setHeight(800);
-  
+
   BynderCompactView.open({
     defaultDomain: config.bynderUrl,
-    mode: "MultiSelect",
-    assetTypes: ["image"],
+    mode: config.selectionMode || "MultiSelect",
+    assetTypes: config.assetTypes || ["image"],
     onSuccess: function (selectedAssets) {
-      let images = currentValue || [];
+      let assets = currentValue || [];
       for (const asset of selectedAssets) {
-        switch (asset.type) {
-          case 'IMAGE':
-            // Avoid duplicates
-            images = images.filter(image => image.id !== asset.id);
-            images.push({
-              id: asset.id,
-              databaseId: asset.databaseId,
-              name: asset.name,
-              bynderUrl: asset.url,
-              updatedAt: asset.updatedAt,
-              description: asset.description,
-              previewUrl: asset.derivatives[config.previewDerivative || 'thumbnail'],
-              webUrl: asset.derivatives[config.webDerivative || "webImage"],
-              files: asset.files
-            });
-            break;
-        }
+        // Avoid duplicates
+        assets = assets.filter(item => item.id !== asset.id);
+        assets.push({
+          id: asset.id,
+          databaseId: asset.databaseId,
+          name: asset.name,
+          bynderUrl: asset.url,
+          updatedAt: asset.updatedAt,
+          description: asset.description,
+          previewUrl: asset.derivatives[config.previewDerivative || 'thumbnail'],
+          webUrl: asset.derivatives[config.webDerivative || "webImage"],
+          files: asset.files
+        });
       }
-      updateValue(images);
+      updateValue(assets);
       updateSize();
     }
   })


### PR DESCRIPTION
### Motivation

We needed some more flexibility in configuring the asset types shown by the custom component and setting the selection mode. We've done this in a backwards compatible way, so it will use the defaults as before.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
