### PR TITLE
AB#1878 Limit to 1 item

### DIFF
--- a/src/bynder-selector.js
+++ b/src/bynder-selector.js
@@ -168,7 +168,7 @@ function openCompactView() {
           continue;
         }
 
-        if (!config.unlimitedItems && assets.length >= maxItems || selectedAssets > maxItems) {
+        if (!config.unlimitedItems && (assets.length >= maxItems || selectedAssets > maxItems)) {
           messages.push(
             `The asset \'<b>${asset.name}</b>\' can't be selected because the maximum of ${maxItems} item(s) has already been reached.`
           );

--- a/src/bynder-selector.js
+++ b/src/bynder-selector.js
@@ -1,6 +1,7 @@
 var currentValue = null;
 var isDisabled = true;
 var config = null;
+var maxItems = 1;
 
 function updateDisabled(disabled) {
   const enabledElements = $(".selector").add(".remove");
@@ -163,6 +164,13 @@ function openCompactView() {
         if (!asset.isPublic && !config.allowNonPublic) {
           messages.push(
             `The asset \'<b>${asset.name}</b>\' can't be selected because it is not marked as <i>Public</i> in Bynder.`
+          );
+          continue;
+        }
+
+        if (!config.unlimitedItems && assets.length >= maxItems) {
+          messages.push(
+            `The asset \'<b>${asset.name}</b>\' can't be selected because the maximum of ${maxItems} item(s) has already been reached.`
           );
           continue;
         }

--- a/src/bynder-selector.js
+++ b/src/bynder-selector.js
@@ -168,7 +168,7 @@ function openCompactView() {
           continue;
         }
 
-        if (!config.unlimitedItems && assets.length >= maxItems) {
+        if (!config.unlimitedItems && assets.length >= maxItems || selectedAssets > maxItems) {
           messages.push(
             `The asset \'<b>${asset.name}</b>\' can't be selected because the maximum of ${maxItems} item(s) has already been reached.`
           );


### PR DESCRIPTION
Config ondersteunt nu de optie: 'unlimitedItems' (true/false).
Bij true is kun je zoveel assets toevoegen als je wilt, bij false of undefined kun je nog maar 1 item toevoegen.

Als er al meerdere items zijn krijg je binnen het bynder element een error message.